### PR TITLE
ci: GHA - Build & Test on PR & merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: Build and Test
+
+on:
+  push:
+    branches:
+      - main
+    pull_request:
+      branches:
+        - main
+
+jobs:
+  build:
+    container: ghcr.io/uneeq-oss/prometheus-mixin-ci:latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Build/Render jsonnet
+        run: |
+          jb install
+          make build
+      - name: Archive manifests for testing and publishing
+        uses: actions/upload-artifact@v2
+        with:
+          name: manifests
+          path: |
+            manifests
+
+  test:
+    container: prom/prometheus:latest
+    needs: [build]
+    steps:
+      - name: Download rendered manifests
+        uses: actions/download-artifact@v2
+        with:
+          name: manifests
+      - name: Prometheus lint rules
+        run: |
+          promtool check rules manifests/prometheus_rules.yaml
+          promtool check rules manifests/prometheus_alerts.yaml
+          promtool test rules tests.yaml


### PR DESCRIPTION
Part 1 of migrating CI from Gitlab - build and test on PR.

Using our OSS container image build/render jsonnet to json dashboards
and yaml Prometheus alerts & rules.

Then using upstream Prometheus image run `promtool` to test syntax and
alert condition tests.

Part 2 to follow separately - release.